### PR TITLE
chore: drop use of pkgjs workflow for testing

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -8,4 +8,23 @@ on:
 
 jobs:
   build:
-    uses: pkgjs/action/.github/workflows/node-test.yaml@v0
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [16.x, 18.x, 20.x]
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        persist-credentials: false
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm ci --ignore-scripts
+    - run: npm run build --if-present
+    - run: npm test
+      env:
+        CI: true


### PR DESCRIPTION
It isn't updating to test only supported Node.js versions. Oh well.